### PR TITLE
Store timesteps in reverse order for consistency.

### DIFF
--- a/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
+++ b/swift/StableDiffusion/pipeline/DPMSolverMultistepScheduler.swift
@@ -178,10 +178,5 @@ public final class DPMSolverMultistepScheduler: Scheduler {
         }
         
         return prevSample
-    }
-    
-    /// This scheduler does not support image2image strength value.
-    public func calculateTimesteps(strength: Float?) -> [Int] {
-        timeSteps
-    }
+    }    
 }

--- a/swift/StableDiffusion/pipeline/Scheduler.swift
+++ b/swift/StableDiffusion/pipeline/Scheduler.swift
@@ -92,12 +92,11 @@ public extension Scheduler {
 
 @available(iOS 16.2, macOS 13.1, *)
 public extension Scheduler {
-    
     func calculateTimesteps(strength: Float?) -> [Int] {
-        guard let strength else { return timeSteps.reversed() }
-        let startStep = Int(Float(inferenceStepCount) * strength)
-        let acutalTimesteps = Array(timeSteps[0..<startStep].reversed())
-        return acutalTimesteps
+        guard let strength else { return timeSteps }
+        let startStep = max(inferenceStepCount - Int(Float(inferenceStepCount) * strength), 0)
+        let actualTimesteps = Array(timeSteps[startStep...])
+        return actualTimesteps
     }
 }
 
@@ -175,7 +174,7 @@ public final class PNDMScheduler: Scheduler {
         timeSteps.append(contentsOf: forwardSteps.dropLast(1))
         timeSteps.append(timeSteps.last!)
         timeSteps.append(forwardSteps.last!)
-        // do no revers timeSteps, this is now done in `calculateTimesteps` function
+        timeSteps.reverse()
 
         self.timeSteps = timeSteps
         self.counter = 0

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -23,7 +23,6 @@ public struct StableDiffusionPipeline: ResourceManaging {
     
     public enum Error: String, Swift.Error {
         case startingImageProvidedWithoutEncoder
-        case schedulerNotSupportedWithImage2Image
     }
 
     /// Model to generate embeddings for tokenized input text
@@ -170,12 +169,6 @@ public struct StableDiffusionPipeline: ResourceManaging {
             timestepStrength = strength
             guard let encoder else {
                 throw Error.startingImageProvidedWithoutEncoder
-            }
-            switch schedulerType {
-            case .pndmScheduler:
-                break
-            case .dpmSolverMultistepScheduler:
-                throw Error.schedulerNotSupportedWithImage2Image
             }
             
             let noiseTuples = generateImage2ImageLatentSamples(imageCount, stdev: 1, seed: seed)

--- a/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
+++ b/swift/StableDiffusion/pipeline/StableDiffusionPipeline.swift
@@ -220,7 +220,7 @@ public struct StableDiffusionPipeline: ResourceManaging {
                 pipeline: self,
                 prompt: prompt,
                 step: step,
-                stepCount: stepCount,
+                stepCount: timeSteps.count,
                 currentLatentSamples: latents,
                 isSafetyEnabled: canSafetyCheck && !disableSafety
             )


### PR DESCRIPTION
Reversal had been moved to the new function `calculateTimesteps`, but only for the PNDM scheduler. This PR goes back to storing timesteps in reverse order in all schedulers.

This fixes image2image generation using `DPMSolverMultistepScheduler`.

----

Thank you for your interest in contributing to Core ML Stable Diffusion! Please review [CONTRIBUTING.md](../CONTRIBUTING.md) first. If you would like to proceed with making a pull request, please indicate your agreement to the terms outlined in CONTRIBUTING.md by checking the box below. If not, please go ahead and fork this repo and make your updates.

We appreciate your interest in the project!

Do not erase the below when submitting your pull request:
#########

- [x] I agree to the terms outlined in CONTRIBUTING.md 
